### PR TITLE
chore: Update workflows to latest Node.js and pin actions by SHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,12 +20,12 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x, 25.x]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       release-created: ${{ steps.release.outputs.release_created }}
       tag-name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
         with:
           config-file: .github/release-please-config.json
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.release-please.outputs.release-created }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '24.x'
+          node-version: '25.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm test

--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -17,6 +17,6 @@ jobs:
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates all GitHub workflows to use the latest versions of Node.js (24.x and 25.x) as of March 2026. It also replaces version-tagged actions with their specific commit SHAs for enhanced security, while maintaining readability by adding the corresponding version number in a comment.

Specifically:
- `actions/checkout` updated to `v6.0.2` (SHA: `de0fac2e4500dabe0009e67214ff5f5447ce83dd`)
- `actions/setup-node` updated to `v6.3.0` (SHA: `53b83947a5a98c8d113130e565377fae1a50d02f`)
- `googleapis/release-please-action` updated to `v4.4.0` (SHA: `16a9c90856f42705d54a6fda1823352bdc62cf38`)
- `amannn/action-semantic-pull-request` updated to `v6.1.1` (SHA: `48f256284bd46cdaab1048c3721360e808335d50`)

---
*PR created automatically by Jules for task [9824934436684515058](https://jules.google.com/task/9824934436684515058) started by @ASaiAnudeep*