### PR TITLE
fix(parser): replace vulnerable csvjson package with secure internal helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.8",
       "license": "ISC",
       "dependencies": {
-        "csvjson": "^5.1.0",
         "globrex": "^0.1.2",
         "parse-jtl": "^1.0.4",
         "totalist": "^3.0.0"
@@ -335,7 +334,8 @@
     "node_modules/csvjson": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/csvjson/-/csvjson-5.1.0.tgz",
-      "integrity": "sha512-OqALQHA0k2rEGluOWikwFq5qtkRUDyoWP2u0UJy8uFjFx5FPMjPzx7D2Hn2KjBLpc8jkGrT9HDNgTUfopDlqVg=="
+      "integrity": "sha512-OqALQHA0k2rEGluOWikwFq5qtkRUDyoWP2u0UJy8uFjFx5FPMjPzx7D2Hn2KjBLpc8jkGrT9HDNgTUfopDlqVg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "homepage": "https://github.com/test-results-reporter/performance-results-parser#readme",
   "dependencies": {
-    "csvjson": "^5.1.0",
     "globrex": "^0.1.2",
     "parse-jtl": "^1.0.4",
     "totalist": "^3.0.0"

--- a/src/helpers/csvjson.js
+++ b/src/helpers/csvjson.js
@@ -1,0 +1,145 @@
+/**
+ * @typedef {Object} ParseOptions
+ * @property {string} [delimiter=','] - The field delimiter.
+ * @property {boolean|string} [quote] - The character used to enclose fields.
+ * @property {string} [headers] - Optional headers to use instead of the first row.
+ */
+
+/**
+ * Stripped-down version of csvjson.toObject with prototype pollution protection.
+ */
+
+function getQuoteChar(q) {
+  if (typeof q === 'string') {
+    return q;
+  } else if (q === true) {
+    return '"';
+  }
+  return null;
+}
+
+function removeQuote(str, quote) {
+  if (str) {
+    const trimmed = String(str).trim();
+    if (quote && trimmed.startsWith(quote) && trimmed.endsWith(quote)) {
+      return trimmed.slice(1, -1);
+    }
+    // Fallback to original behavior of removing any leading/trailing quotes if no specific quote char is provided
+    return trimmed.replace(/^["'](.*)["']$/, '$1');
+  }
+  return '';
+}
+
+function csvToArray(text, delimit, quote) {
+  delimit = delimit || ',';
+  quote = quote || '"';
+
+  // Regular expression to handle quoted and unquoted fields
+  const value = new RegExp(
+    '(?!\\s*$)\\s*(?:' +
+      quote +
+      '([^' +
+      quote +
+      '\\\\]*(?:\\\\.[^' +
+      quote +
+      '\\\\]*)*)' +
+      quote +
+      '|([^' +
+      delimit +
+      quote +
+      '\\s\\\\]*(?:\\s+[^' +
+      delimit +
+      quote +
+      '\\s\\\\]+)*))\\s*(?:' +
+      delimit +
+      '|$)',
+    'g'
+  );
+
+  const a = [];
+  text.replace(value, (m0, m1, m2) => {
+    if (m1 !== undefined) {
+      a.push(m1.replace(/\\'/g, "'"));
+    } else if (m2 !== undefined) {
+      a.push(m2);
+    }
+    return '';
+  });
+
+  if (new RegExp(delimit + '\\s*$').test(text)) {
+    a.push('');
+  }
+  return a;
+}
+
+function convertArray(str, delimiter, quote) {
+  if (quote && str.indexOf(quote) !== -1) {
+    return csvToArray(str, delimiter, quote);
+  }
+  return str.split(delimiter).map(val => val.trim());
+}
+
+/**
+ * Converts CSV string to an array of objects.
+ * @param {string} data - The CSV string to parse.
+ * @param {ParseOptions} [opts] - Parsing options.
+ * @returns {Object[]} An array of objects representing the CSV rows.
+ */
+function toObject(data, opts = {}) {
+  if (typeof data !== 'string') {
+    throw new Error('Invalid input, input data should be a string');
+  }
+
+  const delimiter = opts.delimiter || ',';
+  const quote = getQuoteChar(opts.quote);
+  const lines = data.split(/[\n\r]+/);
+
+  let rawHeaders;
+  if (typeof opts.headers === 'string') {
+    const headerLines = opts.headers.split(/[\n\r]+/);
+    const headerRow = headerLines.shift();
+    rawHeaders = quote
+      ? convertArray(headerRow, delimiter, quote)
+      : headerRow.split(delimiter);
+  } else {
+    const headerRow = lines.shift();
+    if (!headerRow) return [];
+    rawHeaders = quote
+      ? convertArray(headerRow, delimiter, quote)
+      : headerRow.split(delimiter);
+  }
+
+  // Clean headers and identify unsafe keys to prevent prototype pollution
+  // We keep the indices consistent with values by replacing unsafe headers with null
+  const headers = rawHeaders.map(h => {
+    const trimmed = h.trim();
+    if (trimmed === '__proto__' || trimmed === 'constructor' || trimmed === 'prototype') {
+      return null;
+    }
+    return trimmed;
+  });
+
+  const result = [];
+  lines.forEach(line => {
+    if (line.trim()) {
+      const values = quote
+        ? convertArray(line, delimiter, quote)
+        : line.split(delimiter);
+
+      const obj = {};
+      headers.forEach((header, index) => {
+        // Only set the property if the header is safe
+        if (header !== null) {
+          obj[header] = removeQuote(values[index], quote);
+        }
+      });
+      result.push(obj);
+    }
+  });
+
+  return result;
+}
+
+module.exports = {
+  toObject
+};

--- a/src/parsers/jmeter.js
+++ b/src/parsers/jmeter.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const csv_json = require('csvjson');
+const csv_json = require('../helpers/csvjson');
 const { aggregate } = require('parse-jtl');
 const PerformanceTestResult = require('../models/PerformanceTestResult');
 const Transaction = require('../models/Transaction');

--- a/tests/csvjson.helper.spec.js
+++ b/tests/csvjson.helper.spec.js
@@ -1,0 +1,81 @@
+const { toObject } = require('../src/helpers/csvjson');
+const assert = require('assert');
+
+describe('csvjson helper', () => {
+  it('should parse basic CSV', () => {
+    const csv = 'name,age\nAlice,30\nBob,25';
+    const result = toObject(csv);
+    assert.deepStrictEqual(result, [
+      { name: 'Alice', age: '30' },
+      { name: 'Bob', age: '25' }
+    ]);
+  });
+
+  it('should handle different line endings', () => {
+    const csv = 'name,age\r\nAlice,30\rBob,25';
+    const result = toObject(csv);
+    assert.deepStrictEqual(result, [
+      { name: 'Alice', age: '30' },
+      { name: 'Bob', age: '25' }
+    ]);
+  });
+
+  it('should handle custom delimiter', () => {
+    const csv = 'name;age\nAlice;30\nBob;25';
+    const result = toObject(csv, { delimiter: ';' });
+    assert.deepStrictEqual(result, [
+      { name: 'Alice', age: '30' },
+      { name: 'Bob', age: '25' }
+    ]);
+  });
+
+  it('should handle quotes when quote option is true', () => {
+    const csv = '"name","age"\n"Alice","30"\n"Bob","25"';
+    const result = toObject(csv, { quote: true });
+    assert.deepStrictEqual(result, [
+      { name: 'Alice', age: '30' },
+      { name: 'Bob', age: '25' }
+    ]);
+  });
+
+  it('should handle escaped quotes in quoted fields', () => {
+    const csv = '"name","note"\n"Alice","She said \\"Hello\\""';
+    const result = toObject(csv, { quote: true });
+    assert.deepStrictEqual(result, [
+      { name: 'Alice', note: 'She said \\"Hello\\"' }
+    ]);
+  });
+
+  it('should handle custom headers', () => {
+    const csv = 'Alice,30\nBob,25';
+    const result = toObject(csv, { headers: 'name,age' });
+    assert.deepStrictEqual(result, [
+      { name: 'Alice', age: '30' },
+      { name: 'Bob', age: '25' }
+    ]);
+  });
+
+  it('should prevent prototype pollution from headers and avoid column shifting', () => {
+    const csv = 'name,__proto__,age,constructor,city\nAlice,polluted,30,nasty,New York';
+    const result = toObject(csv);
+    assert.deepStrictEqual(result, [
+      { name: 'Alice', age: '30', city: 'New York' }
+    ]);
+    assert.strictEqual({}.polluted, undefined);
+    assert.strictEqual({}.nasty, undefined);
+  });
+
+  it('should handle empty lines', () => {
+    const csv = 'name,age\n\nAlice,30\n\nBob,25\n';
+    const result = toObject(csv);
+    assert.deepStrictEqual(result, [
+      { name: 'Alice', age: '30' },
+      { name: 'Bob', age: '25' }
+    ]);
+  });
+
+  it('should throw error for non-string input', () => {
+    assert.throws(() => toObject(null), /Invalid input/);
+    assert.throws(() => toObject(123), /Invalid input/);
+  });
+});


### PR DESCRIPTION
This PR addresses a security concern regarding the `csvjson` package, which has a known prototype pollution vulnerability and has been unmaintained for several years.

**Changes:**
1.  **New Internal Helper**: Created `src/helpers/csvjson.js` which provides the `toObject` functionality needed for parsing JMeter CSV results.
2.  **Security Mitigation**: The new helper explicitly filters out `__proto__`, `constructor`, and `prototype` keys from CSV headers to prevent prototype pollution attacks.
3.  **Dependency Removal**: Uninstalled the `csvjson` package from the project's dependencies.
4.  **Refactoring**: Updated `src/parsers/jmeter.js` to use the new local helper.
5.  **Testing**: Added `tests/csvjson.helper.spec.js` to verify the new helper's functionality, including its security features and edge cases (custom delimiters, quotes, etc.).

All existing tests pass, and coverage has been maintained.

---
*PR created automatically by Jules for task [12796757570366981563](https://jules.google.com/task/12796757570366981563) started by @ASaiAnudeep*